### PR TITLE
Add `iceberg_polaris_principal_role` resource

### DIFF
--- a/internal/provider/polaris_management_client.go
+++ b/internal/provider/polaris_management_client.go
@@ -56,11 +56,11 @@ func isPolarisNotFoundError(err error) bool {
 
 func (p *icebergProvider) newPolarisManagementClient() (*polarisManagementClient, error) {
 	if p.polaris == nil || p.polaris.managementURI == "" {
-		return nil, fmt.Errorf("polaris is not configured: set type = \"polaris\" and ensure polaris_management_uri is set or derivable from catalog_uri")
+		return nil, errors.New("polaris is not configured: set type = \"polaris\" and ensure polaris_settings.management_uri is set or derivable from catalog_uri")
 	}
 	u, err := url.Parse(p.polaris.managementURI)
 	if err != nil {
-		return nil, fmt.Errorf("invalid polaris_management_uri %q: %w", p.polaris.managementURI, err)
+		return nil, fmt.Errorf("invalid polaris_settings.management_uri %q: %w", p.polaris.managementURI, err)
 	}
 
 	return &polarisManagementClient{
@@ -194,4 +194,53 @@ func (c *polarisManagementClient) UpdatePrincipal(ctx context.Context, name stri
 
 func (c *polarisManagementClient) DeletePrincipal(ctx context.Context, name string) error {
 	return c.do(ctx, http.MethodDelete, "/principals/"+url.PathEscape(name), nil, nil, nil)
+}
+
+type polarisPrincipalRole struct {
+	Name                string            `json:"name"`
+	Federated           *bool             `json:"federated,omitempty"`
+	Properties          map[string]string `json:"properties,omitempty"`
+	EntityVersion       int64             `json:"entityVersion,omitempty"`
+	CreateTimestamp     int64             `json:"createTimestamp,omitempty"`
+	LastUpdateTimestamp int64             `json:"lastUpdateTimestamp,omitempty"`
+}
+
+type polarisCreatePrincipalRoleRequest struct {
+	PrincipalRole polarisPrincipalRole `json:"principalRole"`
+}
+
+type polarisUpdatePrincipalRoleRequest struct {
+	CurrentEntityVersion int64             `json:"currentEntityVersion"`
+	Properties           map[string]string `json:"properties"`
+}
+
+func (c *polarisManagementClient) CreatePrincipalRole(ctx context.Context, req polarisCreatePrincipalRoleRequest) (*polarisPrincipalRole, error) {
+	var out polarisPrincipalRole
+	if err := c.do(ctx, http.MethodPost, "/principal-roles", nil, req, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) GetPrincipalRole(ctx context.Context, name string) (*polarisPrincipalRole, error) {
+	var out polarisPrincipalRole
+	if err := c.do(ctx, http.MethodGet, "/principal-roles/"+url.PathEscape(name), nil, nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) UpdatePrincipalRole(ctx context.Context, name string, req polarisUpdatePrincipalRoleRequest) (*polarisPrincipalRole, error) {
+	var out polarisPrincipalRole
+	if err := c.do(ctx, http.MethodPut, "/principal-roles/"+url.PathEscape(name), nil, req, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *polarisManagementClient) DeletePrincipalRole(ctx context.Context, name string) error {
+	return c.do(ctx, http.MethodDelete, "/principal-roles/"+url.PathEscape(name), nil, nil, nil)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,9 +30,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-var (
-	_ provider.Provider = &icebergProvider{}
-)
+var _ provider.Provider = &icebergProvider{}
 
 // New is a helper function to simplify provider server and testing implementation.
 func New() func() provider.Provider {
@@ -44,13 +42,11 @@ func New() func() provider.Provider {
 // polarisSettingsModel is the Terraform-facing shape of the nested polaris_settings block.
 type polarisSettingsModel struct {
 	ManagementURI types.String `tfsdk:"management_uri"`
-	CatalogName   types.String `tfsdk:"catalog_name"`
 }
 
 // polarisConfig holds Polaris-specific runtime configuration derived from polaris_settings.
 type polarisConfig struct {
 	managementURI string
-	catalogName   string
 }
 
 // icebergProvider is the provider implementation.
@@ -91,9 +87,10 @@ func (p *icebergProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 				Description: "The type of catalog. Use 'rest' for a plain REST catalog, or 'polaris' for Polaris (REST catalog with Polaris management).",
 				Optional:    true,
 			},
-			"token": schema.StringAttribute{Description: "The token to use for authentication.",
-				Optional:  true,
-				Sensitive: true,
+			"token": schema.StringAttribute{
+				Description: "The token to use for authentication.",
+				Optional:    true,
+				Sensitive:   true,
 			},
 			"warehouse": schema.StringAttribute{
 				Description: "The warehouse to use for the Iceberg REST catalog. This will be passed as `warehouse` property in the catalog properties.",
@@ -112,10 +109,6 @@ func (p *icebergProvider) Schema(_ context.Context, _ provider.SchemaRequest, re
 				Attributes: map[string]schema.Attribute{
 					"management_uri": schema.StringAttribute{
 						Description: "The base URI for the Polaris Management API. If omitted, it will be derived from catalog_uri by appending '/api/management/v1'.",
-						Optional:    true,
-					},
-					"catalog_name": schema.StringAttribute{
-						Description: "Default Polaris catalog name for RBAC resources.",
 						Optional:    true,
 					},
 				},
@@ -157,9 +150,6 @@ func (p *icebergProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 		cfg := &polarisConfig{}
 		if data.PolarisSettings != nil {
-			if !data.PolarisSettings.CatalogName.IsNull() && !data.PolarisSettings.CatalogName.IsUnknown() {
-				cfg.catalogName = data.PolarisSettings.CatalogName.ValueString()
-			}
 			if !data.PolarisSettings.ManagementURI.IsNull() && !data.PolarisSettings.ManagementURI.IsUnknown() {
 				cfg.managementURI = strings.TrimRight(data.PolarisSettings.ManagementURI.ValueString(), "/")
 			}
@@ -179,6 +169,7 @@ func (p *icebergProvider) Configure(ctx context.Context, req provider.ConfigureR
 			"Unsupported Catalog Type",
 			"The provider supports 'rest' and 'polaris'. Got: "+catalogType,
 		)
+
 		return
 	}
 
@@ -227,6 +218,7 @@ func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 	for k, v := range h.headers {
 		req.Header.Add(k, v)
 	}
+
 	return http.DefaultTransport.RoundTrip(req)
 }
 
@@ -241,5 +233,6 @@ func (p *icebergProvider) Resources(_ context.Context) []func() resource.Resourc
 		NewNamespaceResource,
 		NewTableResource,
 		NewPolarisPrincipalResource,
+		NewPolarisPrincipalRoleResource,
 	}
 }

--- a/internal/provider/resource_polaris_principal_role.go
+++ b/internal/provider/resource_polaris_principal_role.go
@@ -1,0 +1,350 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource                = &polarisPrincipalRoleResource{}
+	_ resource.ResourceWithImportState = &polarisPrincipalRoleResource{}
+)
+
+func NewPolarisPrincipalRoleResource() resource.Resource {
+	return &polarisPrincipalRoleResource{}
+}
+
+type polarisPrincipalRoleResource struct {
+	provider         *icebergProvider
+	managementClient *polarisManagementClient
+}
+
+type polarisPrincipalRoleResourceModel struct {
+	ID         types.String `tfsdk:"id"`
+	Name       types.String `tfsdk:"name"`
+	Federated  types.Bool   `tfsdk:"federated"`
+	Properties types.Map    `tfsdk:"properties"`
+}
+
+func (r *polarisPrincipalRoleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_polaris_principal_role"
+}
+
+func (r *polarisPrincipalRoleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a Polaris principal role (management API).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Description: "The principal role name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"federated": schema.BoolAttribute{
+				Description: "Whether the role is federated (managed by an external IdP). Updates are not supported by the API; changing this forces replacement.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"properties": schema.MapAttribute{
+				Description: "Metadata properties for the principal role.",
+				Optional:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (r *polarisPrincipalRoleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			"Expected *icebergProvider, got a different type: %T. Please report this issue to the provider developers.",
+		)
+	}
+	r.provider = provider
+}
+
+func (r *polarisPrincipalRoleResource) ensureManagementClient(ctx context.Context, diags *diag.Diagnostics) {
+	if r.managementClient != nil {
+		return
+	}
+	if r.provider == nil {
+		diags.AddError(
+			"Provider not configured",
+			"The provider hasn't been configured before this operation")
+
+		return
+	}
+	client, err := r.provider.newPolarisManagementClient()
+	if err != nil {
+		diags.AddError("Failed to create Polaris management API client", err.Error())
+
+		return
+	}
+	r.managementClient = client
+}
+
+func (r *polarisPrincipalRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleResourceModel
+
+	diags := req.Plan.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+
+	props := make(map[string]string)
+	if !data.Properties.IsNull() && !data.Properties.IsUnknown() {
+		diags = data.Properties.ElementsAs(ctx, &props, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	pr := polarisPrincipalRole{
+		Name:       name,
+		Properties: props,
+	}
+	if !data.Federated.IsNull() && !data.Federated.IsUnknown() {
+		v := data.Federated.ValueBool()
+		pr.Federated = &v
+	}
+
+	tflog.Info(ctx, "Creating Polaris principal role", map[string]any{"name": name})
+
+	created, err := r.managementClient.CreatePrincipalRole(ctx, polarisCreatePrincipalRoleRequest{PrincipalRole: pr})
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(created.Name)
+	data.Name = types.StringValue(created.Name)
+	data.Federated = types.BoolValue(created.Federated != nil && *created.Federated)
+
+	if len(created.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, created.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *polarisPrincipalRoleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleResourceModel
+
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+
+	tflog.Info(ctx, "Reading Polaris principal role", map[string]any{"name": name})
+
+	role, err := r.managementClient.GetPrincipalRole(ctx, name)
+	if err != nil {
+		if isPolarisNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read Polaris principal role", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(role.Name)
+	data.Name = types.StringValue(role.Name)
+	data.Federated = types.BoolValue(role.Federated != nil && *role.Federated)
+
+	if len(role.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, role.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Properties = propsVal
+	} else {
+		data.Properties = types.MapNull(types.StringType)
+	}
+
+	diags = resp.State.Set(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *polarisPrincipalRoleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var plan, state polarisPrincipalRoleResourceModel
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := state.Name.ValueString()
+
+	current, err := r.managementClient.GetPrincipalRole(ctx, name)
+	if err != nil {
+		var nf *polarisNotFoundError
+		if errors.As(err, &nf) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to read Polaris principal role for update", err.Error())
+
+		return
+	}
+
+	props := make(map[string]string)
+	if !plan.Properties.IsNull() && !plan.Properties.IsUnknown() {
+		diags = plan.Properties.ElementsAs(ctx, &props, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	updateReq := polarisUpdatePrincipalRoleRequest{
+		CurrentEntityVersion: current.EntityVersion,
+		Properties:           props,
+	}
+
+	tflog.Info(ctx, "Updating Polaris principal role", map[string]any{"name": name})
+
+	updated, err := r.managementClient.UpdatePrincipalRole(ctx, name, updateReq)
+	if err != nil {
+		var nf *polarisNotFoundError
+		if errors.As(err, &nf) {
+			resp.State.RemoveResource(ctx)
+
+			return
+		}
+		resp.Diagnostics.AddError("Failed to update Polaris principal role", err.Error())
+
+		return
+	}
+
+	state.ID = types.StringValue(updated.Name)
+	state.Name = types.StringValue(updated.Name)
+	state.Federated = types.BoolValue(updated.Federated != nil && *updated.Federated)
+
+	if len(updated.Properties) > 0 {
+		propsVal, diags := types.MapValueFrom(ctx, types.StringType, updated.Properties)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Properties = propsVal
+	} else {
+		state.Properties = types.MapNull(types.StringType)
+	}
+
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *polarisPrincipalRoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	r.ensureManagementClient(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data polarisPrincipalRoleResourceModel
+
+	diags := req.State.Get(ctx, &data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	name := data.Name.ValueString()
+
+	tflog.Info(ctx, "Deleting Polaris principal role", map[string]any{"name": name})
+
+	err := r.managementClient.DeletePrincipalRole(ctx, name)
+	if err != nil && !isPolarisNotFoundError(err) {
+		resp.Diagnostics.AddError("Failed to delete Polaris principal role", err.Error())
+
+		return
+	}
+}
+
+func (r *polarisPrincipalRoleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
+}

--- a/internal/provider/resource_polaris_principal_role_test.go
+++ b/internal/provider/resource_polaris_principal_role_test.go
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccPolarisPrincipalRole_Full runs against a real Polaris deployment.
+func TestAccPolarisPrincipalRole_Full(t *testing.T) {
+	catalogURI := os.Getenv("POLARIS_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("POLARIS_CATALOG_URI not set, skipping real-cluster principal role test")
+	}
+
+	managementURI := strings.TrimRight(catalogURI, "/") + "/api/management/v1"
+	token := os.Getenv("POLARIS_TOKEN")
+
+	providerCfg := testAccPolarisProviderConfigWithToken(catalogURI, managementURI, token)
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
+	roleName := "tf-pr-role-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerCfg + fmt.Sprintf(`
+resource "iceberg_polaris_principal_role" "test" {
+  name = %q
+  properties = {
+    team        = "data"
+    environment = "integration"
+    owner       = "terraform"
+  }
+}
+`, roleName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "name", roleName),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.team", "data"),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.environment", "integration"),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.owner", "terraform"),
+					resource.TestCheckResourceAttr("iceberg_polaris_principal_role.test", "properties.%", "3"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_polaris_principal_test.go
+++ b/internal/provider/resource_polaris_principal_test.go
@@ -36,6 +36,7 @@ func testAccPolarisProviderConfigWithToken(catalogURI, managementURI, token stri
 	if token != "" {
 		tokenAttr = fmt.Sprintf("\n  token = %q", token)
 	}
+
 	return fmt.Sprintf(`
 provider "iceberg" {
   type        = "polaris"
@@ -58,18 +59,21 @@ func newPolarisPrincipalTestServer(t *testing.T) *httptest.Server {
 	mux.HandleFunc("/api/management/v1/principals", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+
 			return
 		}
 
 		var req polarisCreatePrincipalRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+
 			return
 		}
 
 		name := req.Principal.Name
 		if name == "" {
 			http.Error(w, "missing name", http.StatusBadRequest)
+
 			return
 		}
 
@@ -95,6 +99,7 @@ func newPolarisPrincipalTestServer(t *testing.T) *httptest.Server {
 		name := strings.TrimPrefix(r.URL.Path, "/api/management/v1/principals/")
 		if name == "" {
 			http.NotFound(w, r)
+
 			return
 		}
 
@@ -103,6 +108,7 @@ func newPolarisPrincipalTestServer(t *testing.T) *httptest.Server {
 			p, ok := principals[name]
 			if !ok {
 				http.NotFound(w, r)
+
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -110,6 +116,7 @@ func newPolarisPrincipalTestServer(t *testing.T) *httptest.Server {
 		case http.MethodDelete:
 			if _, ok := principals[name]; !ok {
 				http.NotFound(w, r)
+
 				return
 			}
 			delete(principals, name)


### PR DESCRIPTION
Hi team,

I want to propose the following changes in the PR

- `iceberg_polaris_principal_role` resource based on the open api spec [here](https://raw.githubusercontent.com/apache/polaris/refs/heads/main/spec/polaris-management-service.yml) for polaris

- Remove `catalog_name` field in the provider block. It was an oversight from me to include this in the previous PR as `catalog_name` should not be at the provider scope. Ultimately, we would like to keep a single provider block for all catalog names in a polaris deployment

- Minor changes with golangci linter for some of the existing files