### PR TITLE
CI: Use specific patch versions in workflow action comments

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -40,7 +40,7 @@ jobs:
   asf-allowlist-check:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8  # main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -42,7 +42,7 @@ jobs:
         go: [ '1.25.1' ]
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Install Go

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -25,7 +25,7 @@ jobs:
   rat:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - run: |


### PR DESCRIPTION
Similar to https://github.com/apache/iceberg/pull/16229

The workflow files use SHA-pinned actions (immutable), but the human-readable comments referenced only major versions (e.g., `# v6`, `# v5`). 
**When maintainers move these mutable tags to a new commit, zizmor fails in CI because the SHA no longer matches the stated tag.**
