### PR TITLE
Rename repo in codebase

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module github.com/apache/iceberg-terraform
+module github.com/apache/terraform-provider-iceberg
 
 go 1.25.1
 

--- a/main.go
+++ b/main.go
@@ -19,15 +19,14 @@ import (
 	"context"
 	"log"
 
-	"github.com/apache/iceberg-terraform/internal/provider"
+	"github.com/apache/terraform-provider-iceberg/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
-const ADDRESS = "apache.org/iceberg/terraform-provider-iceberg"
+const ADDRESS = "registry.terraform.io/apache/iceberg"
 
 func main() {
 	err := providerserver.Serve(context.Background(), provider.New(), providerserver.ServeOpts{
-		// TODO: This needs to change on release with the published name.
 		Address: ADDRESS,
 	})
 	if err != nil {


### PR DESCRIPTION
Now that the repo has been renamed, we need to make the Go code reflect this. This also changes the provider address, which could never be properly valid because of the repo renaming situation.

[Information on Address naming](https://developer.hashicorp.com/terraform/language/providers/requirements#source-addresses)