### PR TITLE
Update setup-terraform to newest

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -60,6 +60,8 @@ jobs:
         args: --timeout=10m
     - name: Lint
       run: staticcheck ./...
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
     - name: Run tests
       run: go test -v ./...
     - name: Run integration tests


### PR DESCRIPTION
We ran into a weird issue on https://github.com/apache/terraform-provider-iceberg/pull/41 where Terraform tests were failing because of a GPG key.

This isn't our key! It's Hashicorp's. There was apparently an issue with it back in April. I'm not sure why we're facing it now, but there's a couple different solutions.

Solution 1: We're a whole version behind on the setup-terraform action. Let's try that first. It appears to be working?
Solution 2: We install Terraform ourselves (which doesn't do the GPG key check).