### PR TITLE
Add data source for iceberg namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This [Terraform](https://terraform.io) and [OpenTofu](https://www.opentofu.org/)
 
 ## Supported Data Sources
 
+- `iceberg_namespace`: Read metadata for an existing namespace (catalog properties).
 - `iceberg_table`: Read metadata for an existing table (schema, partition spec, sort order, and catalog properties).
 
 ## Supported Resources

--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -1,0 +1,76 @@
+---
+page_title: "iceberg_namespace Data Source - Iceberg"
+subcategory: ""
+description: |-
+  Reads metadata for an existing Iceberg namespace from the catalog.
+---
+
+<!--
+  - Licensed to the Apache Software Foundation (ASF) under one
+  - or more contributor license agreements.  See the NOTICE file
+  - distributed with this work for additional information
+  - regarding copyright ownership.  The ASF licenses this file
+  - to you under the Apache License, Version 2.0 (the
+  - "License"); you may not use this file except in compliance
+  - with the License.  You may obtain a copy of the License at
+  -
+  -   http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing,
+  - software distributed under the License is distributed on an
+  - "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  - KIND, either express or implied.  See the License for the
+  - specific language governing permissions and limitations
+  - under the License.
+  -->
+
+# iceberg_namespace (Data Source)
+
+Reads metadata for an existing Iceberg namespace from the catalog.
+
+Use this data source to inspect namespaces created outside Terraform, to reference namespaces managed in another workspace, or to read the current catalog state of a namespace also managed by an [`iceberg_namespace` resource](../resources/namespace.md).
+
+## Example Usage
+
+### Read a namespace by name
+
+```terraform
+data "iceberg_namespace" "analytics" {
+  name = ["analytics", "prod"]
+}
+
+output "analytics_namespace_id" {
+  value = data.iceberg_namespace.analytics.id
+}
+```
+
+### Read a namespace managed by this provider
+
+```terraform
+resource "iceberg_namespace" "example" {
+  name = ["example_namespace"]
+  user_properties = {
+    description = "An example namespace"
+  }
+}
+
+data "iceberg_namespace" "example" {
+  name = iceberg_namespace.example.name
+}
+```
+
+## Schema
+
+### Required
+
+- `name` (List of String) The name of the namespace.
+
+### Read-Only
+
+- `id` (String) Dot-separated full namespace identifier.
+- `server_properties` (Map of String) Properties returned by the catalog for the namespace.
+
+## Error handling
+
+- If the namespace does not exist, apply fails with a **Namespace not found** error.
+- If `catalog_uri` is not configured on the provider, apply fails with **Catalog not available**.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,7 @@ Use Terraform to interact with Iceberg REST Catalog instances.
 
 ## Data Sources
 
+- [iceberg_namespace](data-sources/namespace.md) — Read metadata for an existing namespace from the catalog.
 - [iceberg_table](data-sources/table.md) — Read metadata for an existing table from the catalog.
 
 ## Resources

--- a/internal/provider/data_source_namespace.go
+++ b/internal/provider/data_source_namespace.go
@@ -169,7 +169,10 @@ func (d *icebergNamespaceDataSource) Read(ctx context.Context, req datasource.Re
 
 			return
 		}
-		resp.Diagnostics.AddError("failed to load namespace", err.Error())
+		resp.Diagnostics.AddError(
+			"failed to load namespace",
+			"namespace "+strings.Join(namespaceIdent, ".")+": "+err.Error(),
+		)
 
 		return
 	}

--- a/internal/provider/data_source_namespace.go
+++ b/internal/provider/data_source_namespace.go
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/apache/iceberg-go/catalog"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	dschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var _ datasource.DataSource = &icebergNamespaceDataSource{}
+
+func NewNamespaceDataSource() datasource.DataSource {
+	return &icebergNamespaceDataSource{}
+}
+
+type icebergNamespaceDataSourceModel struct {
+	ID               types.String `tfsdk:"id"`
+	Name             types.List   `tfsdk:"name"`
+	ServerProperties types.Map    `tfsdk:"server_properties"`
+}
+
+type icebergNamespaceDataSource struct {
+	catalog  catalog.Catalog
+	provider *icebergProvider
+}
+
+func (d *icebergNamespaceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_namespace"
+}
+
+func (d *icebergNamespaceDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = dschema.Schema{
+		Description: "Reads metadata for an existing Iceberg namespace from the catalog.",
+		Attributes: map[string]dschema.Attribute{
+			"id": dschema.StringAttribute{
+				Description: "Dot-separated full namespace identifier.",
+				Computed:    true,
+			},
+			"name": dschema.ListAttribute{
+				Description: "The name of the namespace.",
+				Required:    true,
+				ElementType: types.StringType,
+			},
+			"server_properties": dschema.MapAttribute{
+				Description: "Properties returned by the catalog for the namespace.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+		},
+	}
+}
+
+func (d *icebergNamespaceDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	provider, ok := req.ProviderData.(*icebergProvider)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *icebergProvider, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.provider = provider
+}
+
+func (d *icebergNamespaceDataSource) configureCatalog(ctx context.Context, diags *diag.Diagnostics) {
+	if d.catalog != nil {
+		return
+	}
+
+	if d.provider == nil {
+		diags.AddError(
+			"Provider not configured",
+			"The provider hasn't been configured before this operation",
+		)
+
+		return
+	}
+
+	if d.provider.catalogURI == "" {
+		return
+	}
+
+	cat, err := d.provider.NewCatalog(ctx)
+	if err != nil {
+		diags.AddError(
+			"Failed to create catalog",
+			"Failed to create catalog: "+err.Error(),
+		)
+
+		return
+	}
+	d.catalog = cat
+}
+
+func (d *icebergNamespaceDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	tflog.Info(ctx, "Reading iceberg_namespace data source")
+	d.configureCatalog(ctx, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var data icebergNamespaceDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if d.catalog == nil {
+		resp.Diagnostics.AddError(
+			"Catalog not available",
+			"The catalog could not be created (is catalog_uri set?).",
+		)
+
+		return
+	}
+
+	var namespaceName []string
+	resp.Diagnostics.Append(data.Name.ElementsAs(ctx, &namespaceName, false)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if len(namespaceName) == 0 {
+		resp.Diagnostics.AddError(
+			"Invalid namespace name",
+			"The name attribute must contain at least one namespace segment.",
+		)
+
+		return
+	}
+
+	namespaceIdent := catalog.ToIdentifier(namespaceName...)
+
+	nsProps, err := d.catalog.LoadNamespaceProperties(ctx, namespaceIdent)
+	if err != nil {
+		if errors.Is(err, catalog.ErrNoSuchNamespace) {
+			resp.Diagnostics.AddError(
+				"Namespace not found",
+				"No such namespace: "+strings.Join(namespaceIdent, "."),
+			)
+
+			return
+		}
+		resp.Diagnostics.AddError("failed to load namespace", err.Error())
+
+		return
+	}
+
+	data.ID = types.StringValue(strings.Join(namespaceIdent, "."))
+
+	serverProperties, diags := types.MapValueFrom(ctx, types.StringType, nsProps)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	data.ServerProperties = serverProperties
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/provider/data_source_namespace_test.go
+++ b/internal/provider/data_source_namespace_test.go
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccIcebergNamespaceDataSource_Full(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("ICEBERG_CATALOG_URI not set, skipping namespace data source E2E test")
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIcebergNamespaceDataSourceBasicConfig(providerCfg, "namespace ds description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "name.0", "ns_ds_basic"),
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "id", "ns_ds_basic"),
+					resource.TestCheckResourceAttrPair("data.iceberg_namespace.read", "id", "iceberg_namespace.subject", "id"),
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "server_properties.description", "namespace ds description"),
+				),
+			},
+			{
+				Config: testAccIcebergNamespaceDataSourceNestedConfig(providerCfg),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "name.0", "analytics"),
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "name.1", "prod"),
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "id", "analytics.prod"),
+					resource.TestCheckResourceAttrPair("data.iceberg_namespace.read", "id", "iceberg_namespace.subject", "id"),
+					resource.TestCheckResourceAttr("data.iceberg_namespace.read", "server_properties.owner", "data-team"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIcebergNamespaceDataSource_NotFound(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		t.Skip("ICEBERG_CATALOG_URI not set, skipping namespace data source E2E test")
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccIcebergNamespaceDataSourceMissingConfig(providerCfg),
+				ExpectError: regexp.MustCompile(`Namespace not found`),
+			},
+		},
+	})
+}
+
+func testAccIcebergNamespaceDataSourceBasicConfig(providerCfg string, description string) string {
+	return providerCfg + fmt.Sprintf(`
+resource "iceberg_namespace" "subject" {
+  name = ["ns_ds_basic"]
+  user_properties = {
+    description = "%s"
+  }
+}
+
+data "iceberg_namespace" "read" {
+  name = iceberg_namespace.subject.name
+}
+`, description)
+}
+
+func testAccIcebergNamespaceDataSourceNestedConfig(providerCfg string) string {
+	return providerCfg + `
+resource "iceberg_namespace" "subject" {
+  name = ["analytics", "prod"]
+  user_properties = {
+    owner = "data-team"
+  }
+}
+
+data "iceberg_namespace" "read" {
+  name = iceberg_namespace.subject.name
+}
+`
+}
+
+func testAccIcebergNamespaceDataSourceMissingConfig(providerCfg string) string {
+	return providerCfg + `
+data "iceberg_namespace" "missing" {
+  name = ["definitely_no_such_namespace"]
+}
+`
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -234,6 +234,7 @@ func (h *headerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error
 // DataSources defines the data sources implemented in the provider.
 func (p *icebergProvider) DataSources(_ context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{
+		NewNamespaceDataSource,
 		NewTableDataSource,
 	}
 }


### PR DESCRIPTION
Hi team, I'm adding a new data source for namespace. The interface for user is something like below

```terraform
data "iceberg_namespace" "analytics" {
  name = ["analytics", "prod"]
}

output "analytics_namespace_id" {
  value = data.iceberg_namespace.analytics.id
}
```