### PR TITLE
Fix(bug): Fix bug in precommit hook for golangci-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-files: ^go/
-
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.8.0
     hooks:
       - id: golangci-lint
-        entry: bash -c 'cd iceberg && golangci-lint run --fix --timeout 5m'
-        types_or: [go]
+        args: [--fix, --timeout=5m]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,4 @@ repos:
     hooks:
       - id: golangci-lint
         args: [--fix, --timeout=5m]
+        types_or: [go, go-mod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@
 ---
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.8.0
+    rev: c0d3ddc9cf3faa61a4e378e879ece580256d76e5 # frozen: v2.12.2
     hooks:
       - id: golangci-lint
         args: [--fix, --timeout=5m]


### PR DESCRIPTION
Fixing some error from precommit hook . There is no `iceberg` folder but `terraform-provider-iceberg`
I'm taking reference from this https://github.com/apache/terraform-provider-iceberg/blob/e95ff7ce0c7cb9b51ba5c8dcf4217e7fda8d469a/.github/workflows/go-ci.yml#L57-L60