### PR TITLE
Pin Iceberg REST Fixture

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -16,7 +16,7 @@
 version: "3"
 services:
   rest:
-    image: apache/iceberg-rest-fixture
+    image: apache/iceberg-rest-fixture:1.10.1
     container_name: iceberg-rest
     networks:
       iceberg_net:

--- a/internal/provider/resource_namespace_test.go
+++ b/internal/provider/resource_namespace_test.go
@@ -88,6 +88,68 @@ func TestAccIcebergNamespace(t *testing.T) {
 	})
 }
 
+func TestAccIcebergNamespaceNested(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		catalogURI = "http://localhost:8181"
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Create a multi-level namespace with a property. This exercises
+				// the URL-encoded unit separator (%1F) used to join the name
+				// parts and confirms properties round-trip on nested namespaces.
+				Config: testAccIcebergNamespaceNestedConfig(providerCfg, "data-team"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_namespace.nested", "name.0", "analytics"),
+					resource.TestCheckResourceAttr("iceberg_namespace.nested", "name.1", "prod"),
+					resource.TestCheckResourceAttr("iceberg_namespace.nested", "id", "analytics.prod"),
+					resource.TestCheckResourceAttr("iceberg_namespace.nested", "user_properties.owner", "data-team"),
+					resource.TestCheckResourceAttr("iceberg_namespace.nested", "server_properties.owner", "data-team"),
+				),
+			},
+			{
+				// Drop the property so the state has no user_properties before
+				// import (import cannot reconstruct user-managed properties).
+				Config: testAccIcebergNamespaceNestedConfig(providerCfg, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_namespace.nested", "id", "analytics.prod"),
+					resource.TestCheckNoResourceAttr("iceberg_namespace.nested", "user_properties.owner"),
+				),
+			},
+			{
+				ResourceName:      "iceberg_namespace.nested",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"server_properties",
+				},
+			},
+		},
+	})
+}
+
+func testAccIcebergNamespaceNestedConfig(providerCfg string, owner string) string {
+	propsStr := ""
+	if owner != "" {
+		propsStr = fmt.Sprintf(`user_properties = {
+    owner = "%s"
+  }`, owner)
+	}
+
+	return providerCfg + fmt.Sprintf(`
+resource "iceberg_namespace" "nested" {
+  name = ["analytics", "prod"]
+  %s
+}
+`, propsStr)
+}
+
 func testAccIcebergNamespaceResourceConfig(providerCfg string, description string) string {
 	propsStr := ""
 	if description != "" {


### PR DESCRIPTION
We've had an unpinned version of the iceberg-rest-fixture (which isn't a great practice!). 

This ended up finding an issue in iceberg-go around the REST namespace separator. iceberg-go's namespace separator character is now returning a Jetty error on the REST Fixture.

The fix is upstream in iceberg-go, but for now, let's have a simple test + pin the fixture.