### PR TITLE
Verify RC Cleanup failure

### DIFF
--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -175,7 +175,9 @@ ensure_go() {
     if go version; then
       GOPATH="${VERIFY_TMPDIR}/gopath"
       export GOPATH
-      mkdir -p "${GOPATH}"
+      GOMODCACHE="${GOPATH}/pkg/mod"
+      export GOMODCACHE
+      mkdir -p "${GOMODCACHE}"
       return
     fi
   fi
@@ -218,7 +220,9 @@ ensure_go() {
   export GOROOT
   GOPATH="$(pwd)/gopath"
   export GOPATH
-  mkdir -p "${GOPATH}"
+  GOMODCACHE="${GOPATH}/pkg/mod"
+  export GOMODCACHE
+  mkdir -p "${GOMODCACHE}"
   PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
 }
 

--- a/dev/release/verify_rc.sh
+++ b/dev/release/verify_rc.sh
@@ -65,6 +65,7 @@ VERIFY_SUCCESS=no
 
 setup_tmpdir() {
   cleanup() {
+    go clean -modcache || :
     if [ "${VERIFY_SUCCESS}" = "yes" ]; then
       rm -rf "${VERIFY_TMPDIR}"
     else


### PR DESCRIPTION
When the verify_rc.sh script finishes, the cleanup fails because only `go clean -modcache` can delete the cache.

This doesn't impact the results of the script or the ability for it to verify.