### PR TITLE
Remove all Polaris references and make version a env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This [Terraform](https://terraform.io) and [OpenTofu](https://www.opentofu.org/)
 
 - `iceberg_namespace`: Manage Iceberg namespaces and their properties.
 - `iceberg_table`: Manage Iceberg tables, including schema definitions and properties.
-- `iceberg_polaris_principal`: Manage Polaris principals and client credentials (when using a Polaris catalog).
 
 See the [provider documentation](docs/index.md) for examples and attribute reference.
 

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,8 @@
 # --- Configuration ---
 PROVIDER_NAMESPACE="apache"
 PROVIDER_TYPE="iceberg"
-VERSION="1.0.0" 
+# Local dev build, not a release. Override with VERSION=0.1.0 ./build.sh
+VERSION="${VERSION:-0.0.0}"
 BINARY_BASE_NAME="terraform-provider-iceberg"
 BINARY_NAME="${BINARY_BASE_NAME}_v${VERSION}"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,6 @@ Use Terraform to interact with Iceberg REST Catalog instances.
 
 - [iceberg_namespace](resources/namespace.md) — Manage a catalog namespace.
 - [iceberg_table](resources/table.md) — Manage an Iceberg table.
-- [iceberg_polaris_principal](resources/polaris_principal.md) — Manage a Polaris principal (Polaris deployments).
 
 ## Schema
 

--- a/internal/provider/data_source_table_test.go
+++ b/internal/provider/data_source_table_test.go
@@ -24,8 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestAccIcebergTableDataSource_Full runs end-to-end against a real REST catalog when ICEBERG_CATALOG_URI is set
-// (same pattern as TestAccPolarisPrincipal_Full and the integration Makefile targets).
+// TestAccIcebergTableDataSource_Full runs end-to-end against a real REST catalog when ICEBERG_CATALOG_URI is set.
 func TestAccIcebergTableDataSource_Full(t *testing.T) {
 	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
 	if catalogURI == "" {


### PR DESCRIPTION
I'm taking a couple of build nits from the email thread and putting them in a single PR.

This removes all Polaris references (`grep -ri polaris` to verify). It also makes the VERSION on the build script configurable.