### PR TITLE
Handle schema evolution on table update

### DIFF
--- a/internal/provider/resource_table.go
+++ b/internal/provider/resource_table.go
@@ -471,6 +471,13 @@ func (r *icebergTableResource) calculateSchemaUpdates(ctx context.Context, plan,
 		return nil
 	}
 
+	// Reject changes that aren't a valid Iceberg evolution before committing.
+	if err := validateSchemaEvolution(tbl.Schema(), planIceberg); err != nil {
+		diags.AddError("invalid schema evolution", err.Error())
+
+		return nil
+	}
+
 	// Find the highest existing schema ID to ensure the new one is unique.
 	maxSchemaID := int64(0)
 	for _, s := range tbl.Metadata().Schemas() {

--- a/internal/provider/resource_table_test.go
+++ b/internal/provider/resource_table_test.go
@@ -155,6 +155,108 @@ func TestAccIcebergTableUpdate(t *testing.T) {
 	})
 }
 
+func testAccIcebergTableEvolutionConfig(providerCfg, tableName, dataType string, dataRequired bool) string {
+	return providerCfg + fmt.Sprintf(`
+resource "iceberg_namespace" "db_evo" {
+  name = ["db_evo"]
+}
+
+resource "iceberg_table" "test" {
+  namespace = iceberg_namespace.db_evo.name
+  name      = "%s"
+  schema = {
+    fields = [
+      {
+        id       = 1
+        name     = "id"
+        type     = "long"
+        required = true
+      },
+      {
+        id       = 2
+        name     = "data"
+        type     = "%s"
+        required = %t
+      }
+    ]
+  }
+}
+`, tableName, dataType, dataRequired)
+}
+
+func TestAccIcebergTableInvalidEvolution(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		catalogURI = "http://localhost:8181"
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+	tableName := "invalid_evolution_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIcebergTableEvolutionConfig(providerCfg, tableName, "long", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.type", "long"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.id", "0"),
+				),
+			},
+			{
+				// long -> string is not a valid Iceberg type promotion.
+				Config:      testAccIcebergTableEvolutionConfig(providerCfg, tableName, "string", false),
+				ExpectError: regexp.MustCompile(`(?s)invalid schema evolution.*not a valid type promotion`),
+			},
+			{
+				// optional -> required is not an allowed schema evolution.
+				Config:      testAccIcebergTableEvolutionConfig(providerCfg, tableName, "long", true),
+				ExpectError: regexp.MustCompile(`(?s)invalid schema evolution.*optional to required`),
+			},
+			{
+				// Neither rejected change reached the catalog, so the table is
+				// still on its original schema version.
+				Config: testAccIcebergTableEvolutionConfig(providerCfg, tableName, "long", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.type", "long"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.required", "false"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.id", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIcebergTableValidEvolution(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		catalogURI = "http://localhost:8181"
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+	tableName := "valid_evolution_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIcebergTableEvolutionConfig(providerCfg, tableName, "int", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.type", "int"),
+				),
+			},
+			{
+				Config: testAccIcebergTableEvolutionConfig(providerCfg, tableName, "long", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.type", "long"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccIcebergTablePropertiesUpdate(t *testing.T) {
 	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
 	if catalogURI == "" {

--- a/internal/provider/table_schema.go
+++ b/internal/provider/table_schema.go
@@ -17,6 +17,7 @@ package provider
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/apache/iceberg-go"
@@ -99,6 +100,59 @@ func (s *icebergTableSchema) FromIceberg(icebergSchema *iceberg.Schema) error {
 	}
 
 	return json.Unmarshal(b, s)
+}
+
+// validateSchemaEvolution returns an error if a field present in both schemas
+// changes in a way Iceberg disallows. Fields are matched by ID, so additions
+// and deletions are always permitted.
+func validateSchemaEvolution(current, planned *iceberg.Schema) error {
+	currentByID, err := iceberg.IndexByID(current)
+	if err != nil {
+		return err
+	}
+	plannedByID, err := iceberg.IndexByID(planned)
+	if err != nil {
+		return err
+	}
+
+	for id, cur := range currentByID {
+		if plan, ok := plannedByID[id]; ok {
+			if err := validateFieldEvolution(cur, plan); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func validateFieldEvolution(cur, plan iceberg.NestedField) error {
+	if !cur.Required && plan.Required {
+		return fmt.Errorf("field %q (id %d): changing a field from optional to required is not an allowed schema evolution", cur.Name, cur.ID)
+	}
+
+	curPrim, curIsPrim := cur.Type.(iceberg.PrimitiveType)
+	planPrim, planIsPrim := plan.Type.(iceberg.PrimitiveType)
+
+	if !curIsPrim || !planIsPrim {
+		// Nested fields carry their own IDs and are checked separately, so only
+		// the container kind matters here.
+		if cur.Type.Type() != plan.Type.Type() {
+			return fmt.Errorf("field %q (id %d): cannot change field type from %s to %s", cur.Name, cur.ID, cur.Type, plan.Type)
+		}
+
+		return nil
+	}
+
+	// PromoteType rejects a type as a promotion of itself, so only call it when
+	// the type actually changed.
+	if !planPrim.Equals(curPrim) {
+		if _, err := iceberg.PromoteType(curPrim, planPrim); err != nil {
+			return fmt.Errorf("field %q (id %d): %s is not a valid type promotion from %s: %w", cur.Name, cur.ID, plan.Type, cur.Type, err)
+		}
+	}
+
+	return nil
 }
 
 type icebergTablePartitionSpec struct {

--- a/internal/provider/table_schema_test.go
+++ b/internal/provider/table_schema_test.go
@@ -1,0 +1,183 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/iceberg-go"
+)
+
+// schemaOf builds a single-field schema for "data" with id 2, alongside a
+// fixed required "id" field so the fixtures resemble a real table.
+func schemaOf(dataType iceberg.Type, dataRequired bool) *iceberg.Schema {
+	return iceberg.NewSchema(0,
+		iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true},
+		iceberg.NestedField{ID: 2, Name: "data", Type: dataType, Required: dataRequired},
+	)
+}
+
+func listOf(element iceberg.Type) iceberg.Type {
+	return &iceberg.ListType{ElementID: 3, Element: element, ElementRequired: false}
+}
+
+func structOf(fieldType iceberg.Type) iceberg.Type {
+	return &iceberg.StructType{FieldList: []iceberg.NestedField{
+		{ID: 3, Name: "nested", Type: fieldType, Required: false},
+	}}
+}
+
+func TestValidateSchemaEvolution(t *testing.T) {
+	tests := []struct {
+		name    string
+		current *iceberg.Schema
+		planned *iceberg.Schema
+		wantErr string
+	}{
+		{
+			name:    "unchanged",
+			current: schemaOf(iceberg.PrimitiveTypes.String, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.String, false),
+		},
+		{
+			name:    "rename",
+			current: iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "old", Type: iceberg.PrimitiveTypes.String}),
+			planned: iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "new", Type: iceberg.PrimitiveTypes.String}),
+		},
+		{
+			name:    "add field",
+			current: iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+			planned: schemaOf(iceberg.PrimitiveTypes.String, false),
+		},
+		{
+			name:    "drop field",
+			current: schemaOf(iceberg.PrimitiveTypes.String, false),
+			planned: iceberg.NewSchema(0, iceberg.NestedField{ID: 1, Name: "id", Type: iceberg.PrimitiveTypes.Int64, Required: true}),
+		},
+		{
+			name:    "int to long",
+			current: schemaOf(iceberg.PrimitiveTypes.Int32, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.Int64, false),
+		},
+		{
+			name:    "float to double",
+			current: schemaOf(iceberg.PrimitiveTypes.Float32, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.Float64, false),
+		},
+		{
+			name:    "decimal widened precision",
+			current: schemaOf(iceberg.DecimalTypeOf(9, 2), false),
+			planned: schemaOf(iceberg.DecimalTypeOf(18, 2), false),
+		},
+		{
+			name:    "required to optional",
+			current: schemaOf(iceberg.PrimitiveTypes.String, true),
+			planned: schemaOf(iceberg.PrimitiveTypes.String, false),
+		},
+		{
+			name:    "list element promoted",
+			current: schemaOf(listOf(iceberg.PrimitiveTypes.Int32), false),
+			planned: schemaOf(listOf(iceberg.PrimitiveTypes.Int64), false),
+		},
+		{
+			name:    "long to string",
+			current: schemaOf(iceberg.PrimitiveTypes.Int64, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.String, false),
+			wantErr: `field "data" (id 2): string is not a valid type promotion from long`,
+		},
+		{
+			name:    "string to long",
+			current: schemaOf(iceberg.PrimitiveTypes.String, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.Int64, false),
+			wantErr: `field "data" (id 2): long is not a valid type promotion from string`,
+		},
+		{
+			name:    "long to int",
+			current: schemaOf(iceberg.PrimitiveTypes.Int64, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.Int32, false),
+			wantErr: `field "data" (id 2): int is not a valid type promotion from long`,
+		},
+		{
+			name:    "double to float",
+			current: schemaOf(iceberg.PrimitiveTypes.Float64, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.Float32, false),
+			wantErr: `field "data" (id 2): float is not a valid type promotion from double`,
+		},
+		{
+			name:    "decimal reduced precision",
+			current: schemaOf(iceberg.DecimalTypeOf(18, 2), false),
+			planned: schemaOf(iceberg.DecimalTypeOf(9, 2), false),
+			wantErr: `field "data" (id 2): decimal(9, 2) is not a valid type promotion from decimal(18, 2)`,
+		},
+		{
+			name:    "optional to required",
+			current: schemaOf(iceberg.PrimitiveTypes.String, false),
+			planned: schemaOf(iceberg.PrimitiveTypes.String, true),
+			wantErr: `field "data" (id 2): changing a field from optional to required is not an allowed schema evolution`,
+		},
+		{
+			name:    "primitive to struct",
+			current: schemaOf(iceberg.PrimitiveTypes.String, false),
+			planned: schemaOf(structOf(iceberg.PrimitiveTypes.String), false),
+			wantErr: `field "data" (id 2): cannot change field type from string to struct<`,
+		},
+		{
+			name:    "struct to primitive",
+			current: schemaOf(structOf(iceberg.PrimitiveTypes.String), false),
+			planned: schemaOf(iceberg.PrimitiveTypes.String, false),
+			wantErr: `field "data" (id 2): cannot change field type from struct<`,
+		},
+		{
+			name:    "list to struct",
+			current: schemaOf(listOf(iceberg.PrimitiveTypes.String), false),
+			planned: schemaOf(structOf(iceberg.PrimitiveTypes.String), false),
+			wantErr: `field "data" (id 2): cannot change field type from list<string> to struct<`,
+		},
+		{
+			name:    "list element demoted",
+			current: schemaOf(listOf(iceberg.PrimitiveTypes.Int64), false),
+			planned: schemaOf(listOf(iceberg.PrimitiveTypes.String), false),
+			wantErr: `field "element" (id 3): string is not a valid type promotion from long`,
+		},
+		{
+			name:    "struct field demoted",
+			current: schemaOf(structOf(iceberg.PrimitiveTypes.Int64), false),
+			planned: schemaOf(structOf(iceberg.PrimitiveTypes.String), false),
+			wantErr: `field "nested" (id 3): string is not a valid type promotion from long`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSchemaEvolution(tt.current, tt.planned)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
+				return
+			}
+
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We should validate that any update schema properly follows Iceberg's rules on schema evolution.

On table updates, we should verify that:
- Type promotions are allowed
- Can't make an optional field required

Note: iceberg-go incorrectly allows changing decimal scale. This was solved in a PR, but hasn't been released yet. We should upgrade Terraform's iceberg-go after next release.