### PR TITLE
Handle optional field IDs

### DIFF
--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -83,6 +83,29 @@ resource "iceberg_table" "example" {
 }
 ```
 
+## Renaming columns
+
+Each field is identified by its `id`, not its name. The provider matches a field
+to its existing column by `id` when one is set, and otherwise by name. So renaming
+a column without keeping its `id` reads as dropping the old column and adding a new
+one — which loses that column's data.
+
+To rename a column while preserving its data, set the field's `id` to the existing
+column's id:
+
+```terraform
+schema = {
+  fields = [
+    {
+      id       = 1        # keep the id of the column being renamed
+      name     = "user_id"
+      type     = "long"
+      required = true
+    }
+  ]
+}
+```
+
 ## Schema
 
 ### Required
@@ -125,7 +148,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
+- `id` (Number) The field ID, stable across updates. Auto-assigned if omitted. To rename a column, keep its id; otherwise it is dropped and re-added.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties))
@@ -140,7 +163,7 @@ Required:
 
 Optional:
 
-- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
+- `element_id` (Number) The list element id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--map_properties"></a>
@@ -154,8 +177,8 @@ Required:
 
 Optional:
 
-- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
-- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
+- `key_id` (Number) The map key id. Auto-assigned if omitted.
+- `value_id` (Number) The map value id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties"></a>
@@ -177,7 +200,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
+- `id` (Number) The field ID, stable across updates. Auto-assigned if omitted. To rename a column, keep its id; otherwise it is dropped and re-added.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties))
@@ -192,7 +215,7 @@ Required:
 
 Optional:
 
-- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
+- `element_id` (Number) The list element id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--map_properties"></a>
@@ -206,8 +229,8 @@ Required:
 
 Optional:
 
-- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
-- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
+- `key_id` (Number) The map key id. Auto-assigned if omitted.
+- `value_id` (Number) The map value id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties"></a>
@@ -229,7 +252,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
+- `id` (Number) The field ID, stable across updates. Auto-assigned if omitted. To rename a column, keep its id; otherwise it is dropped and re-added.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties))
@@ -244,7 +267,7 @@ Required:
 
 Optional:
 
-- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
+- `element_id` (Number) The list element id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--map_properties"></a>
@@ -258,8 +281,8 @@ Required:
 
 Optional:
 
-- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
-- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
+- `key_id` (Number) The map key id. Auto-assigned if omitted.
+- `value_id` (Number) The map value id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties"></a>
@@ -281,7 +304,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
+- `id` (Number) The field ID, stable across updates. Auto-assigned if omitted. To rename a column, keep its id; otherwise it is dropped and re-added.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties))
@@ -296,7 +319,7 @@ Required:
 
 Optional:
 
-- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
+- `element_id` (Number) The list element id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties"></a>
@@ -310,8 +333,8 @@ Required:
 
 Optional:
 
-- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
-- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
+- `key_id` (Number) The map key id. Auto-assigned if omitted.
+- `value_id` (Number) The map value id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties"></a>
@@ -333,7 +356,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
+- `id` (Number) The field ID, stable across updates. Auto-assigned if omitted. To rename a column, keep its id; otherwise it is dropped and re-added.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties))
@@ -348,7 +371,7 @@ Required:
 
 Optional:
 
-- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
+- `element_id` (Number) The list element id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties"></a>
@@ -362,8 +385,8 @@ Required:
 
 Optional:
 
-- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
-- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
+- `key_id` (Number) The map key id. Auto-assigned if omitted.
+- `value_id` (Number) The map value id. Auto-assigned if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties"></a>

--- a/docs/resources/table.md
+++ b/docs/resources/table.md
@@ -73,7 +73,6 @@ resource "iceberg_table" "example" {
         name = "tags"
         type = "list"
         list_properties = {
-          element_id       = 3
           element_type     = "string"
           element_required = true
         }
@@ -126,7 +125,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID.
+- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties))
@@ -136,9 +135,12 @@ Optional:
 
 Required:
 
-- `element_id` (Number) The list element id.
 - `element_required` (Boolean) Whether the list element is required.
 - `element_type` (String) The list element type.
+
+Optional:
+
+- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--map_properties"></a>
@@ -146,11 +148,14 @@ Required:
 
 Required:
 
-- `key_id` (Number) The map key id.
 - `key_type` (String) The map key type.
-- `value_id` (Number) The map value id.
 - `value_required` (Boolean) Whether the map value is required.
 - `value_type` (String) The map value type.
+
+Optional:
+
+- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
+- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties"></a>
@@ -172,7 +177,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID.
+- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties))
@@ -182,9 +187,12 @@ Optional:
 
 Required:
 
-- `element_id` (Number) The list element id.
 - `element_required` (Boolean) Whether the list element is required.
 - `element_type` (String) The list element type.
+
+Optional:
+
+- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--map_properties"></a>
@@ -192,11 +200,14 @@ Required:
 
 Required:
 
-- `key_id` (Number) The map key id.
 - `key_type` (String) The map key type.
-- `value_id` (Number) The map value id.
 - `value_required` (Boolean) Whether the map value is required.
 - `value_type` (String) The map value type.
+
+Optional:
+
+- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
+- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties"></a>
@@ -218,7 +229,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID.
+- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties))
@@ -228,9 +239,12 @@ Optional:
 
 Required:
 
-- `element_id` (Number) The list element id.
 - `element_required` (Boolean) Whether the list element is required.
 - `element_type` (String) The list element type.
+
+Optional:
+
+- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--map_properties"></a>
@@ -238,11 +252,14 @@ Required:
 
 Required:
 
-- `key_id` (Number) The map key id.
 - `key_type` (String) The map key type.
-- `value_id` (Number) The map value id.
 - `value_required` (Boolean) Whether the map value is required.
 - `value_type` (String) The map value type.
+
+Optional:
+
+- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
+- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties"></a>
@@ -264,7 +281,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID.
+- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties))
@@ -274,9 +291,12 @@ Optional:
 
 Required:
 
-- `element_id` (Number) The list element id.
 - `element_required` (Boolean) Whether the list element is required.
 - `element_type` (String) The list element type.
+
+Optional:
+
+- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties"></a>
@@ -284,11 +304,14 @@ Required:
 
 Required:
 
-- `key_id` (Number) The map key id.
 - `key_type` (String) The map key type.
-- `value_id` (Number) The map value id.
 - `value_required` (Boolean) Whether the map value is required.
 - `value_type` (String) The map value type.
+
+Optional:
+
+- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
+- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties"></a>
@@ -310,7 +333,7 @@ Required:
 Optional:
 
 - `doc` (String) The field documentation.
-- `id` (Number) The field ID.
+- `id` (Number) The field ID. Assigned automatically by the provider if omitted.
 - `list_properties` (Attributes) Properties for list type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--list_properties))
 - `map_properties` (Attributes) Properties for map type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties))
 - `struct_properties` (Attributes) Properties for struct type. (see [below for nested schema](#nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties))
@@ -320,9 +343,12 @@ Optional:
 
 Required:
 
-- `element_id` (Number) The list element id.
 - `element_required` (Boolean) Whether the list element is required.
 - `element_type` (String) The list element type.
+
+Optional:
+
+- `element_id` (Number) The list element id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--map_properties"></a>
@@ -330,11 +356,14 @@ Required:
 
 Required:
 
-- `key_id` (Number) The map key id.
 - `key_type` (String) The map key type.
-- `value_id` (Number) The map value id.
 - `value_required` (Boolean) Whether the map value is required.
 - `value_type` (String) The map value type.
+
+Optional:
+
+- `key_id` (Number) The map key id. Assigned automatically by the provider if omitted.
+- `value_id` (Number) The map value id. Assigned automatically by the provider if omitted.
 
 
 <a id="nestedatt--schema--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties--fields--struct_properties"></a>

--- a/examples/resources/iceberg_table/resource.tf
+++ b/examples/resources/iceberg_table/resource.tf
@@ -40,7 +40,6 @@ resource "iceberg_table" "example" {
         name = "tags"
         type = "list"
         list_properties = {
-          element_id       = 3
           element_type     = "string"
           element_required = true
         }

--- a/internal/provider/resource_table.go
+++ b/internal/provider/resource_table.go
@@ -200,6 +200,10 @@ func (r *icebergTableResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
+	// Assign IDs to any omitted fields; otherwise they serialize as 0 and the
+	// catalog rejects the schema for duplicate field IDs.
+	schema.assignFieldIDs(0)
+
 	tblSchema, err := schema.ToIceberg()
 	if err != nil {
 		resp.Diagnostics.AddError("failed to convert schema", err.Error())
@@ -447,6 +451,10 @@ func (r *icebergTableResource) calculateSchemaUpdates(ctx context.Context, plan,
 	if diags.HasError() {
 		return nil
 	}
+
+	// Assign IDs to new fields above the table's last-column-id so they never
+	// collide with an existing or previously-dropped field.
+	planSchema.assignFieldIDs(int64(tbl.Metadata().LastColumnID()))
 
 	planIceberg, err := planSchema.ToIceberg()
 	if err != nil {

--- a/internal/provider/resource_table.go
+++ b/internal/provider/resource_table.go
@@ -200,8 +200,8 @@ func (r *icebergTableResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 
-	// Assign IDs to any omitted fields; otherwise they serialize as 0 and the
-	// catalog rejects the schema for duplicate field IDs.
+	// Fill omitted IDs; otherwise they serialize as 0 and the catalog rejects
+	// the schema for duplicate field IDs.
 	schema.assignFieldIDs(0)
 
 	tblSchema, err := schema.ToIceberg()
@@ -452,8 +452,9 @@ func (r *icebergTableResource) calculateSchemaUpdates(ctx context.Context, plan,
 		return nil
 	}
 
-	// Assign IDs to new fields above the table's last-column-id so they never
-	// collide with an existing or previously-dropped field.
+	// Reuse existing IDs by name (stable across inserts/reorders), then assign
+	// fresh IDs above last-column-id to new fields.
+	planSchema.resolveFieldIDs(&stateSchema)
 	planSchema.assignFieldIDs(int64(tbl.Metadata().LastColumnID()))
 
 	planIceberg, err := planSchema.ToIceberg()

--- a/internal/provider/resource_table.go
+++ b/internal/provider/resource_table.go
@@ -203,6 +203,11 @@ func (r *icebergTableResource) Create(ctx context.Context, req resource.CreateRe
 	// Fill omitted IDs; otherwise they serialize as 0 and the catalog rejects
 	// the schema for duplicate field IDs.
 	schema.assignFieldIDs(0)
+	if err := schema.validateFieldIDs(); err != nil {
+		resp.Diagnostics.AddError("duplicate field id", err.Error())
+
+		return
+	}
 
 	tblSchema, err := schema.ToIceberg()
 	if err != nil {
@@ -456,6 +461,11 @@ func (r *icebergTableResource) calculateSchemaUpdates(ctx context.Context, plan,
 	// fresh IDs above last-column-id to new fields.
 	planSchema.resolveFieldIDs(&stateSchema)
 	planSchema.assignFieldIDs(int64(tbl.Metadata().LastColumnID()))
+	if err := planSchema.validateFieldIDs(); err != nil {
+		diags.AddError("duplicate field id", err.Error())
+
+		return nil
+	}
 
 	planIceberg, err := planSchema.ToIceberg()
 	if err != nil {

--- a/internal/provider/resource_table_test.go
+++ b/internal/provider/resource_table_test.go
@@ -155,6 +155,77 @@ func TestAccIcebergTableUpdate(t *testing.T) {
 	})
 }
 
+func testAccIcebergTableOmittedIDsConfig(providerCfg string, tableName string) string {
+	return providerCfg + fmt.Sprintf(`
+resource "iceberg_namespace" "db_omit" {
+  name = ["db_omit"]
+}
+
+resource "iceberg_table" "test" {
+  namespace = iceberg_namespace.db_omit.name
+  name      = "%s"
+  schema = {
+    fields = [
+      {
+        name     = "id"
+        type     = "long"
+        required = true
+      },
+      {
+        name     = "data"
+        type     = "string"
+        required = false
+      },
+      {
+        name     = "tags"
+        type     = "list"
+        required = false
+        list_properties = {
+          element_type     = "string"
+          element_required = true
+        }
+      }
+    ]
+  }
+}
+`, tableName)
+}
+
+func TestAccIcebergTableOmittedFieldIDs(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		catalogURI = "http://localhost:8181"
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+	tableName := "omitted_ids_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIcebergTableOmittedIDsConfig(providerCfg, tableName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.#", "3"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.0.name", "id"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.0.id", "1"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.name", "data"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.id", "2"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.name", "tags"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.id", "3"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.list_properties.element_id", "4"),
+				),
+			},
+			{
+				// Re-applying the identical config must be a no-op.
+				Config:   testAccIcebergTableOmittedIDsConfig(providerCfg, tableName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccIcebergTableEvolutionConfig(providerCfg, tableName, dataType string, dataRequired bool) string {
 	return providerCfg + fmt.Sprintf(`
 resource "iceberg_namespace" "db_evo" {

--- a/internal/provider/resource_table_test.go
+++ b/internal/provider/resource_table_test.go
@@ -318,6 +318,57 @@ func TestAccIcebergTableInsertField(t *testing.T) {
 	})
 }
 
+func testAccIcebergTableDuplicateIDsConfig(providerCfg, tableName string) string {
+	return providerCfg + fmt.Sprintf(`
+resource "iceberg_namespace" "db_dup" {
+  name = ["db_dup"]
+}
+
+resource "iceberg_table" "test" {
+  namespace = iceberg_namespace.db_dup.name
+  name      = "%s"
+  schema = {
+    fields = [
+      {
+        id       = 1
+        name     = "id"
+        type     = "long"
+        required = true
+      },
+      {
+        id       = 1
+        name     = "data"
+        type     = "string"
+        required = false
+      }
+    ]
+  }
+}
+`, tableName)
+}
+
+func TestAccIcebergTableDuplicateFieldIDs(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		catalogURI = "http://localhost:8181"
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+	tableName := "duplicate_ids_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Two fields sharing an explicit id must fail before commit.
+				Config:      testAccIcebergTableDuplicateIDsConfig(providerCfg, tableName),
+				ExpectError: regexp.MustCompile(`(?s)duplicate field id.*reuses id 1`),
+			},
+		},
+	})
+}
+
 func testAccIcebergTableEvolutionConfig(providerCfg, tableName, dataType string, dataRequired bool) string {
 	return providerCfg + fmt.Sprintf(`
 resource "iceberg_namespace" "db_evo" {

--- a/internal/provider/resource_table_test.go
+++ b/internal/provider/resource_table_test.go
@@ -226,6 +226,98 @@ func TestAccIcebergTableOmittedFieldIDs(t *testing.T) {
 	})
 }
 
+func testAccIcebergTableInsertFieldConfig(providerCfg, tableName string, withMiddle bool) string {
+	middle := ""
+	if withMiddle {
+		middle = `
+      {
+        name     = "middle"
+        type     = "int"
+        required = false
+      },`
+	}
+
+	return providerCfg + fmt.Sprintf(`
+resource "iceberg_namespace" "db_insert" {
+  name = ["db_insert"]
+}
+
+resource "iceberg_table" "test" {
+  namespace = iceberg_namespace.db_insert.name
+  name      = "%s"
+  schema = {
+    fields = [
+      {
+        name     = "id"
+        type     = "long"
+        required = true
+      },%s
+      {
+        name     = "data"
+        type     = "string"
+        required = false
+      },
+      {
+        name     = "tags"
+        type     = "list"
+        required = false
+        list_properties = {
+          element_type     = "string"
+          element_required = true
+        }
+      }
+    ]
+  }
+}
+`, tableName, middle)
+}
+
+func TestAccIcebergTableInsertField(t *testing.T) {
+	catalogURI := os.Getenv("ICEBERG_CATALOG_URI")
+	if catalogURI == "" {
+		catalogURI = "http://localhost:8181"
+	}
+
+	providerCfg := fmt.Sprintf(providerConfig, catalogURI)
+	tableName := "insert_field_table"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIcebergTableInsertFieldConfig(providerCfg, tableName, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.0.id", "1"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.id", "2"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.id", "3"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.list_properties.element_id", "4"),
+				),
+			},
+			{
+				// Inserting a field in the middle must keep every existing
+				// column's ID and give only the new column a fresh one.
+				Config: testAccIcebergTableInsertFieldConfig(providerCfg, tableName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.0.name", "id"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.0.id", "1"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.name", "middle"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.1.id", "5"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.name", "data"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.2.id", "2"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.3.name", "tags"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.3.id", "3"),
+					resource.TestCheckResourceAttr("iceberg_table.test", "schema.fields.3.list_properties.element_id", "4"),
+				),
+			},
+			{
+				Config:   testAccIcebergTableInsertFieldConfig(providerCfg, tableName, true),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func testAccIcebergTableEvolutionConfig(providerCfg, tableName, dataType string, dataRequired bool) string {
 	return providerCfg + fmt.Sprintf(`
 resource "iceberg_namespace" "db_evo" {

--- a/internal/provider/table_schema.go
+++ b/internal/provider/table_schema.go
@@ -102,6 +102,80 @@ func (s *icebergTableSchema) FromIceberg(icebergSchema *iceberg.Schema) error {
 	return json.Unmarshal(b, s)
 }
 
+// fieldIDUnset reports whether a field ID was left unspecified. Iceberg reserves
+// 0 for the table root, so 0 (like null/unknown) is never a valid field ID.
+func fieldIDUnset(id types.Int64) bool {
+	return id.IsNull() || id.IsUnknown() || id.ValueInt64() == 0
+}
+
+// assignFieldIDs fills unset field IDs (including nested struct, list, and map
+// IDs) with fresh values, preserving any the user set. New IDs are allocated
+// above startAfter and every ID already present, keeping them unique within the
+// schema and against startAfter (pass the table's last-column-id on update).
+func (s *icebergTableSchema) assignFieldIDs(startAfter int64) {
+	maxID := startAfter
+
+	var scan func(fields []icebergTableSchemaField)
+	scan = func(fields []icebergTableSchemaField) {
+		for _, f := range fields {
+			maxID = maxSetID(maxID, f.ID)
+			if f.ListProperties != nil {
+				maxID = maxSetID(maxID, f.ListProperties.ID)
+			}
+			if f.MapProperties != nil {
+				maxID = maxSetID(maxID, f.MapProperties.KeyID)
+				maxID = maxSetID(maxID, f.MapProperties.ValueID)
+			}
+			if f.StructProperties != nil {
+				scan(f.StructProperties.Fields)
+			}
+		}
+	}
+	scan(s.Fields)
+
+	next := func() types.Int64 {
+		maxID++
+
+		return types.Int64Value(maxID)
+	}
+
+	var assign func(fields []icebergTableSchemaField)
+	assign = func(fields []icebergTableSchemaField) {
+		for i := range fields {
+			f := &fields[i]
+			if fieldIDUnset(f.ID) {
+				f.ID = next()
+			}
+			if f.ListProperties != nil && fieldIDUnset(f.ListProperties.ID) {
+				f.ListProperties.ID = next()
+			}
+			if f.MapProperties != nil {
+				if fieldIDUnset(f.MapProperties.KeyID) {
+					f.MapProperties.KeyID = next()
+				}
+				if fieldIDUnset(f.MapProperties.ValueID) {
+					f.MapProperties.ValueID = next()
+				}
+			}
+			if f.StructProperties != nil {
+				assign(f.StructProperties.Fields)
+			}
+		}
+	}
+	assign(s.Fields)
+}
+
+func maxSetID(current int64, id types.Int64) int64 {
+	if fieldIDUnset(id) {
+		return current
+	}
+	if v := id.ValueInt64(); v > current {
+		return v
+	}
+
+	return current
+}
+
 // validateSchemaEvolution returns an error if a field present in both schemas
 // changes in a way Iceberg disallows. Fields are matched by ID, so additions
 // and deletions are always permitted.

--- a/internal/provider/table_schema.go
+++ b/internal/provider/table_schema.go
@@ -238,6 +238,58 @@ func (s *icebergTableSchema) resolveFieldIDs(prior *icebergTableSchema) {
 	apply("", s.Fields)
 }
 
+// validateFieldIDs rejects an id used by more than one field. Field, list
+// element, map key/value, and nested ids share one space; users may set them, so
+// collisions must fail before commit.
+func (s *icebergTableSchema) validateFieldIDs() error {
+	seen := map[int64]string{}
+
+	var walk func(path string, fields []icebergTableSchemaField) error
+	walk = func(path string, fields []icebergTableSchemaField) error {
+		for _, f := range fields {
+			name := path + f.Name
+			if err := claimFieldID(seen, f.ID, name); err != nil {
+				return err
+			}
+			if f.ListProperties != nil {
+				if err := claimFieldID(seen, f.ListProperties.ID, name+".element"); err != nil {
+					return err
+				}
+			}
+			if f.MapProperties != nil {
+				if err := claimFieldID(seen, f.MapProperties.KeyID, name+".key"); err != nil {
+					return err
+				}
+				if err := claimFieldID(seen, f.MapProperties.ValueID, name+".value"); err != nil {
+					return err
+				}
+			}
+			if f.StructProperties != nil {
+				if err := walk(name+".", f.StructProperties.Fields); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}
+
+	return walk("", s.Fields)
+}
+
+func claimFieldID(seen map[int64]string, id types.Int64, name string) error {
+	if fieldIDUnset(id) {
+		return nil
+	}
+	v := id.ValueInt64()
+	if prev, ok := seen[v]; ok {
+		return fmt.Errorf("field %q reuses id %d already assigned to %q", name, v, prev)
+	}
+	seen[v] = name
+
+	return nil
+}
+
 // validateSchemaEvolution returns an error if a field present in both schemas
 // changes in a way Iceberg disallows. Fields are matched by ID, so additions
 // and deletions are always permitted.

--- a/internal/provider/table_schema.go
+++ b/internal/provider/table_schema.go
@@ -102,16 +102,15 @@ func (s *icebergTableSchema) FromIceberg(icebergSchema *iceberg.Schema) error {
 	return json.Unmarshal(b, s)
 }
 
-// fieldIDUnset reports whether a field ID was left unspecified. Iceberg reserves
-// 0 for the table root, so 0 (like null/unknown) is never a valid field ID.
+// fieldIDUnset reports an unspecified field ID: null, unknown, or 0 (Iceberg
+// reserves 0 for the table root).
 func fieldIDUnset(id types.Int64) bool {
 	return id.IsNull() || id.IsUnknown() || id.ValueInt64() == 0
 }
 
-// assignFieldIDs fills unset field IDs (including nested struct, list, and map
-// IDs) with fresh values, preserving any the user set. New IDs are allocated
-// above startAfter and every ID already present, keeping them unique within the
-// schema and against startAfter (pass the table's last-column-id on update).
+// assignFieldIDs fills unset IDs (nested struct/list/map included) with fresh
+// values above startAfter and every existing ID, preserving user-set ones. Pass
+// the table's last-column-id on update.
 func (s *icebergTableSchema) assignFieldIDs(startAfter int64) {
 	maxID := startAfter
 
@@ -174,6 +173,69 @@ func maxSetID(current int64, id types.Int64) int64 {
 	}
 
 	return current
+}
+
+// fieldIDs holds one field's IDs: the field plus any list/map element/key/value.
+type fieldIDs struct {
+	id      types.Int64
+	element types.Int64
+	key     types.Int64
+	value   types.Int64
+}
+
+// resolveFieldIDs reuses prior IDs for same-named fields (matched by path, so
+// nested fields stay scoped to their parent), keeping IDs stable across
+// inserts/reorders. Fills only unset IDs.
+func (s *icebergTableSchema) resolveFieldIDs(prior *icebergTableSchema) {
+	byPath := map[string]fieldIDs{}
+
+	var index func(path string, fields []icebergTableSchemaField)
+	index = func(path string, fields []icebergTableSchemaField) {
+		for _, f := range fields {
+			key := path + "/" + f.Name
+			ids := fieldIDs{id: f.ID}
+			if f.ListProperties != nil {
+				ids.element = f.ListProperties.ID
+			}
+			if f.MapProperties != nil {
+				ids.key = f.MapProperties.KeyID
+				ids.value = f.MapProperties.ValueID
+			}
+			byPath[key] = ids
+			if f.StructProperties != nil {
+				index(key, f.StructProperties.Fields)
+			}
+		}
+	}
+	index("", prior.Fields)
+
+	var apply func(path string, fields []icebergTableSchemaField)
+	apply = func(path string, fields []icebergTableSchemaField) {
+		for i := range fields {
+			f := &fields[i]
+			key := path + "/" + f.Name
+			if match, ok := byPath[key]; ok {
+				if fieldIDUnset(f.ID) {
+					f.ID = match.id
+				}
+				if f.ListProperties != nil && fieldIDUnset(f.ListProperties.ID) {
+					f.ListProperties.ID = match.element
+				}
+				if f.MapProperties != nil {
+					if fieldIDUnset(f.MapProperties.KeyID) {
+						f.MapProperties.KeyID = match.key
+					}
+					if fieldIDUnset(f.MapProperties.ValueID) {
+						f.MapProperties.ValueID = match.value
+					}
+				}
+			}
+			if f.StructProperties != nil {
+				apply(key, f.StructProperties.Fields)
+			}
+		}
+	}
+	apply("", s.Fields)
 }
 
 // validateSchemaEvolution returns an error if a field present in both schemas

--- a/internal/provider/table_schema.go
+++ b/internal/provider/table_schema.go
@@ -110,7 +110,8 @@ func fieldIDUnset(id types.Int64) bool {
 
 // assignFieldIDs fills unset IDs (nested struct/list/map included) with fresh
 // values above startAfter and every existing ID, preserving user-set ones. Pass
-// the table's last-column-id on update.
+// the table's last-column-id on update so new IDs don't reuse retired columns'.
+// Fresh IDs are unique by construction; user-set ones need validateFieldIDs.
 func (s *icebergTableSchema) assignFieldIDs(startAfter int64) {
 	maxID := startAfter
 

--- a/internal/provider/table_tfschema.go
+++ b/internal/provider/table_tfschema.go
@@ -125,7 +125,7 @@ func tableSortOrderDataSourceAttributes() map[string]dschema.Attribute {
 func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribute {
 	attrs := map[string]rscschema.Attribute{
 		"id": rscschema.Int64Attribute{
-			Description: "The field ID. Assigned automatically by the provider if omitted.",
+			Description: "The field ID, stable across updates. Auto-assigned if omitted. To rename a column, keep its id; otherwise it is dropped and re-added.",
 			Optional:    true,
 			Computed:    true,
 		},
@@ -150,7 +150,7 @@ func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribut
 			Optional:    true,
 			Attributes: map[string]rscschema.Attribute{
 				"element_id": rscschema.Int64Attribute{
-					Description: "The list element id. Assigned automatically by the provider if omitted.",
+					Description: "The list element id. Auto-assigned if omitted.",
 					Optional:    true,
 					Computed:    true,
 				},
@@ -169,7 +169,7 @@ func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribut
 			Optional:    true,
 			Attributes: map[string]rscschema.Attribute{
 				"key_id": rscschema.Int64Attribute{
-					Description: "The map key id. Assigned automatically by the provider if omitted.",
+					Description: "The map key id. Auto-assigned if omitted.",
 					Optional:    true,
 					Computed:    true,
 				},
@@ -178,7 +178,7 @@ func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribut
 					Required:    true,
 				},
 				"value_id": rscschema.Int64Attribute{
-					Description: "The map value id. Assigned automatically by the provider if omitted.",
+					Description: "The map value id. Auto-assigned if omitted.",
 					Optional:    true,
 					Computed:    true,
 				},

--- a/internal/provider/table_tfschema.go
+++ b/internal/provider/table_tfschema.go
@@ -125,8 +125,9 @@ func tableSortOrderDataSourceAttributes() map[string]dschema.Attribute {
 func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribute {
 	attrs := map[string]rscschema.Attribute{
 		"id": rscschema.Int64Attribute{
-			Description: "The field ID.",
+			Description: "The field ID. Assigned automatically by the provider if omitted.",
 			Optional:    true,
+			Computed:    true,
 		},
 		"name": rscschema.StringAttribute{
 			Description: "The field name.",
@@ -149,8 +150,9 @@ func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribut
 			Optional:    true,
 			Attributes: map[string]rscschema.Attribute{
 				"element_id": rscschema.Int64Attribute{
-					Description: "The list element id.",
-					Required:    true,
+					Description: "The list element id. Assigned automatically by the provider if omitted.",
+					Optional:    true,
+					Computed:    true,
 				},
 				"element_type": rscschema.StringAttribute{
 					Description: "The list element type.",
@@ -167,16 +169,18 @@ func tableSchemaFieldResourceAttributes(depth int) map[string]rscschema.Attribut
 			Optional:    true,
 			Attributes: map[string]rscschema.Attribute{
 				"key_id": rscschema.Int64Attribute{
-					Description: "The map key id.",
-					Required:    true,
+					Description: "The map key id. Assigned automatically by the provider if omitted.",
+					Optional:    true,
+					Computed:    true,
 				},
 				"key_type": rscschema.StringAttribute{
 					Description: "The map key type.",
 					Required:    true,
 				},
 				"value_id": rscschema.Int64Attribute{
-					Description: "The map value id.",
-					Required:    true,
+					Description: "The map value id. Assigned automatically by the provider if omitted.",
+					Optional:    true,
+					Computed:    true,
 				},
 				"value_type": rscschema.StringAttribute{
 					Description: "The map value type.",


### PR DESCRIPTION
Right now, all field IDs that aren't specified get set to 0. That's a problem.

This PR does the following:
- Makes field IDs truly optional (changes docs too)
- Walks the schema + assigns field IDs based on the running max to any unassigned fields